### PR TITLE
Facebook strict mode compatible oauth

### DIFF
--- a/Facebook/OAuthFacebook.php
+++ b/Facebook/OAuthFacebook.php
@@ -8,10 +8,6 @@ use Keboola\Syrup\Exception\ApplicationException;
 use Keboola\OAuth\AbstractOAuth;
 use function Keboola\Utils\jsonDecode;
 
-use Facebook\Facebook;
-use Facebook\Exceptions\FacebookSDKException;
-use Facebook\Exceptions\FacebookResponseException;
-
 class OAuthFacebook extends AbstractOAuth
 {
     const GRANT_TYPE = 'authorization_code';
@@ -62,9 +58,7 @@ class OAuthFacebook extends AbstractOAuth
                 throw new UserException(
                     "OAuth authentication failed[{$errCode}]: {$message}",
                     null,
-                    [
-                        'response' => $e->getResponse()->getBody()
-                    ]
+                    ['response' => $e->getResponse()->getBody()]
                 );
             } else {
                 throw $e;

--- a/Facebook/OAuthFacebook.php
+++ b/Facebook/OAuthFacebook.php
@@ -18,6 +18,9 @@ class OAuthFacebook extends AbstractOAuth
     /**
      * @todo NEEDS app_key/secret, auth_url, request_token_url (1.0)
      * 2.0 will need redir_url along with auth_url, app_key
+     *
+     * @param string $callbackUrl
+     * @return array
      */
     public function createRedirectData($callbackUrl)
     {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "keboola/php-utils": "~1.0",
         "guzzlehttp/guzzle": "^6.1",
         "keboola/syrup-php-client": "^4.1",
-        "facebook/graph-sdk": "~5.0"
+        "facebook/graph-sdk": "~5.0",
+        "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
         "phpunit\/phpunit": "^5.0"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "keboola/php-utils": "~1.0",
         "guzzlehttp/guzzle": "^6.1",
         "keboola/syrup-php-client": "^4.1",
-        "facebook/graph-sdk": "~5.0",
         "paragonie/random_compat": "^2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -1091,64 +1091,6 @@
             "time": "2015-09-17T22:01:44+00:00"
         },
         {
-            "name": "facebook/graph-sdk",
-            "version": "5.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/facebook/php-graph-sdk.git",
-                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/2f9639c15ae043911f40ffe44080b32bac2c5280",
-                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.4|^7.0"
-            },
-            "require-dev": {
-                "guzzlehttp/guzzle": "~5.0",
-                "mockery/mockery": "~0.8",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "guzzlehttp/guzzle": "Allows for implementation of the Guzzle HTTP client",
-                "paragonie/random_compat": "Provides a better CSPRNG option in PHP 5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Facebook\\": "src/Facebook/"
-                },
-                "files": [
-                    "src/Facebook/polyfills.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Facebook Platform"
-            ],
-            "authors": [
-                {
-                    "name": "Facebook",
-                    "homepage": "https://github.com/facebook/php-graph-sdk/contributors"
-                }
-            ],
-            "description": "Facebook SDK for PHP",
-            "homepage": "https://github.com/facebook/php-graph-sdk",
-            "keywords": [
-                "facebook",
-                "sdk"
-            ],
-            "time": "2017-08-16T17:28:07+00:00"
-        },
-        {
             "name": "guzzle/guzzle",
             "version": "v3.9.3",
             "source": {

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -30,7 +30,10 @@ adjust-logs:
 	chmod +x ./adjust-logs.sh
 	./adjust-logs.sh
 
-docker-dev: clean-all composer-install setup-dirs copy-parameters-yml adjust-logs
+migrate-db:
+    docker-compose run --rm apache ./vendor/keboola/syrup/app/console --no-interactions doctrine:migrations:migrate
+
+docker-dev: clean-all composer-install setup-dirs copy-parameters-yml adjust-logs migrate-db
 
 build-images:
 	docker-compose build

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,7 @@ this command does the following:
 - set 777 permissions on vendor dir
 - copies both parameters files
 - adjust logs
+- migrates DB - creates DB tables
 
 ### 4. Logging
 Script `./adjust-logs.sh` or `make adjust-logs` command in `docker` dir to adjusts logs to dump the exceptions log directly to the screen. See the `adjust-logs.sh` script for more details. This script is called automatically on `make docker-dev` command;


### PR DESCRIPTION
FIXES #33 

- vyhodeny facebook/graph-sdk package ktory implementoval fb autorizaciu
- manualne implementovana facebook autorizacia pomocou `response_type=code`
- generuje long lived access token pre facebook tak ako to bolo doteraz
- podporuje csrf protection(cez state v session)
